### PR TITLE
bug fixing in gulp script:release task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ const eslint = require('gulp-eslint');
 const sourcemaps = require('gulp-sourcemaps');
 const uglify = require('gulp-uglify');
 const mocha = require('gulp-mocha');
+const babel = require('gulp-babel');
 
 /**
  * function to handle errors from any task
@@ -128,13 +129,14 @@ gulp.task('scripts:development', bundleJs({
 }));
 
 // from src directory to distribution directory - release/production mode
-gulp.task('scripts:release', bundleJs({
-  srcDir: 'src',
-  srcFile: 'index.js',
-  destDir: 'dist',
-  destFile: 'index.js',
-  development: false,
-}));
+gulp.task('scripts:release', function() {
+  return gulp.src([
+    'src/**/*.js',
+    'src/**/*.jsx',
+  ])
+    .pipe(babel())
+    .pipe(gulp.dest('dist'));
+});
 
 /**
  * task to initial tests using mocha

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0",
     "gulp": "^3.9.1",
+    "gulp-babel": "^6.1.2",
     "gulp-eslint": "^3.0.1",
     "gulp-mocha": "^4.1.0",
     "gulp-sourcemaps": "^2.4.1",


### PR DESCRIPTION
Fixes the bug in `script:release` gulp task where browserfiy/babelify was being used to generate the release scripts causing the final of size of module in distribution to be of >200K now this size will be reduced by 10 times 